### PR TITLE
Add missing key to other project template

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,4 +24,4 @@
 {% endfor %}
 
 {% assign other = site.data.projects.other %}
-{% include language_section.html data=other %}
+{% include language_section.html key='other' data=other %}


### PR DESCRIPTION
Clicking other on the nav doesnt work, while it has the appropriate `#other` there is no matching id.