### PR TITLE
add AtprotoAuth

### DIFF
--- a/_data/projects/ruby.yml
+++ b/_data/projects/ruby.yml
@@ -6,3 +6,4 @@ repos:
   - url: https://github.com/mackuba/skyfall
   - url: https://github.com/mackuba/bluesky-feeds-rb
   - url: https://github.com/lasercatspro/omniauth-atproto
+  - url: https://github.com/jhuckabee/atproto_auth


### PR DESCRIPTION
A Ruby implementation of the AT Protocol OAuth specification. This library provides support for both client and server-side implementations, with built-in security features including DPoP, PAR, and dynamic client registration.